### PR TITLE
Remove decimals from Bitcoin prices

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,14 +61,15 @@ async function fetchBitcoinData(): Promise<Partial<BitcoinData>> {
     const response = await fetch("/api/bitcoin")
     const data = await response.json()
 
-    const btcPriceUSD = data.bitcoin.usd
-    const btcPriceLKR = data.bitcoin.lkr
+    const btcPriceUSD = Math.round(data.bitcoin.usd)
+    const rawLKR = data.bitcoin.lkr
+    const btcPriceLKR = Math.round(rawLKR)
 
     return {
       btcPriceUSD,
       btcPriceLKR,
-      satsPerLKR: Number((100000000 / btcPriceLKR).toFixed(2)),
-      lkrPerSat: Number((btcPriceLKR / 100000000).toFixed(4)),
+      satsPerLKR: Number((100000000 / rawLKR).toFixed(2)),
+      lkrPerSat: Number((rawLKR / 100000000).toFixed(4)),
       blockHeight: data.blockHeight,
       mempool: data.mempool.count,
       fees: 12, // Default fee rate
@@ -115,8 +116,8 @@ export default function BitcoinDashboard() {
             const btcPriceLKR = btcPriceUSD * usdToLkrRate
             const newData = {
               ...prev,
-              btcPriceUSD,
-              btcPriceLKR,
+              btcPriceUSD: Math.round(btcPriceUSD),
+              btcPriceLKR: Math.round(btcPriceLKR),
               satsPerLKR: Number((100000000 / btcPriceLKR).toFixed(2)),
               lkrPerSat: Number((btcPriceLKR / 100000000).toFixed(4)),
               priceChange24h,
@@ -177,15 +178,15 @@ export default function BitcoinDashboard() {
               <h3 className="text-xl text-muted-foreground mb-4">Bitcoin Price (LKR)</h3>
               <div className="text-6xl font-bold text-primary mb-2">
                 <FlowingNumber
-                  value={data.btcPriceLKR.toLocaleString()}
-                  previousValue={previousData.btcPriceLKR.toLocaleString()}
+                  value={data.btcPriceLKR.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  previousValue={previousData.btcPriceLKR.toLocaleString(undefined, { maximumFractionDigits: 0 })}
                   prefix="රු. "
                 />
               </div>
               <div className="text-lg text-muted-foreground">
                 <FlowingNumber
-                  value={data.btcPriceUSD.toLocaleString()}
-                  previousValue={previousData.btcPriceUSD.toLocaleString()}
+                  value={data.btcPriceUSD.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  previousValue={previousData.btcPriceUSD.toLocaleString(undefined, { maximumFractionDigits: 0 })}
                   prefix="$"
                 />
               </div>


### PR DESCRIPTION
## Summary
- Round Bitcoin USD/LKR values from APIs and websocket updates
- Format Bitcoin price displays without decimals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a86e845e4c832cbf440d17a8f0a510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision for sats-per-LKR and LKR-per-sat by computing with higher-precision values behind the scenes.

* **Style**
  * Bitcoin prices (LKR and USD) now display as whole numbers with locale-aware formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->